### PR TITLE
Cory test

### DIFF
--- a/pages/patterns/accordion.md
+++ b/pages/patterns/accordion.md
@@ -38,4 +38,4 @@ last-updated: 5/18/2021
 <!--- to learn markdown format go to https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax -->
 
 ### Accessibility:
-Accordion trgger heading level may need to change based on which section the component is implmented
+When implementing an accordion on a page, the trigger's heading level may need to change. The heading level for the trigger is based on the heading level of the section of the page that the accordion is resides in. If the accordion is added to a section that has a heading level 3 then the trigger for the accordion would be a heading level 4 (as in this example). But if the accordion is implemented in a section with a heading level 2 then the accordion trigger would need to be a heading level 3 to maintain a logical heading order hirearchy.

--- a/pages/patterns/alerts.md
+++ b/pages/patterns/alerts.md
@@ -44,5 +44,8 @@ schema:
 
 
 last-updated: 5/18/2021
----
 
+---
+### Accessibility
+Besure to use the correct heading level when implementing alerts. Besure not to skip heading levels.
+When implementing alerts for form validation it is important to convey the number of errors, state which form field is in error and provide instructions to users on how to receover from the error

--- a/pages/patterns/button.md
+++ b/pages/patterns/button.md
@@ -37,7 +37,7 @@ Button text should be as short as possible and lead with action words that clear
 
 ## Accessibility
 It is critical that buttons conform to Section 508 best practices so that they can be used successfully by everyone. 
-So, contrast of the button and text colors should meet W3C guidelines and alt text is required for all button text, except for disabled buttons (as disabled elements do not need to be read). 
+So, contrast of the button and text colors should meet W3C guidelines and alt text is required for all button text, except for disabled buttons (as disabled elements do not need to be read). Disabled buttons are exempt from the minimum contrast ratio requirements.
 Note that these buttons, if used as designed, are 508 compliant.
 
 


### PR DESCRIPTION
Added some accessibility notes regarding heading levels for Accordion triggers, using the Alert pattern for form validation error messages and contrast ratio for disabled buttons (disabled buttons are exempt from contrast ratio minimums.

My branch still shows I am 11 commits behind the master branch but I did not see that we went over syncing up with the master branch during our session on the 16th. I checked YouTube for some videos but what I Saw looked different from our instance. I'll check again in the morning.